### PR TITLE
Add DevSecCon 2025 keynote to Speaking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@
 
 <br clear="right"/>
 
-<a href="https://www.youtube.com/watch?v=kwIzRkzO_Z4"><img src="https://zackproser.b-cdn.net/images/devseccon-2025-keynote.webp" width="420" alt="DevSecCon 2025 Keynote — Watch on YouTube" align="right" /></a>
-
-- **[DevSecCon 2025 Keynote](https://www.youtube.com/watch?v=kwIzRkzO_Z4)** — Delivered the keynote address on AI and security. 32-minute talk covering how AI agents are reshaping the security landscape.
-
-<br clear="right"/>
-
 <a href="https://zackproser.com/blog/walking-and-talking-with-ai"><img src="https://zackproser.b-cdn.net/images/walking-talking-ai.webp" width="420" alt="Voice-first development from the trails" align="right" /></a>
 
 - **Voice-first development** — Ship production code at 179 WPM using WisprFlow. Orchestrate multiple AI agents by voice from mountain trails. ([Read more](https://zackproser.com/blog/walking-and-talking-with-ai))
@@ -80,6 +74,8 @@
   <a href="https://zackproser.com/blog/claude-cowork-workshop-anthropic"><img src="https://zackproser.b-cdn.net/images/claude-cowork-martijn-lancee.webp" width="440" alt="Full crowd at the Claude Cowork GTM Workshop — WorkOS x Anthropic, Feb 2026" /></a>
   &nbsp;&nbsp;
   <a href="https://zackproser.com/blog/a16z-sf-dec-2023-ai-apps-production"><img src="https://zackproser.b-cdn.net/images/a16z-3.webp" width="440" alt="Presenting at a16z San Francisco, Dec 2023" /></a>
+  &nbsp;&nbsp;
+  <a href="https://www.youtube.com/watch?v=kwIzRkzO_Z4"><img src="https://zackproser.b-cdn.net/images/devseccon-2025-keynote.webp" width="440" alt="DevSecCon 2025 Keynote — Watch on YouTube" /></a>
 </p>
 
 | Event | What | When |

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@
 ### Speaking & Workshops
 
 <p align="center">
-  <a href="https://zackproser.com/blog/claude-cowork-workshop-anthropic"><img src="https://zackproser.b-cdn.net/images/claude-cowork-martijn-lancee.webp" width="440" alt="Full crowd at the Claude Cowork GTM Workshop — WorkOS x Anthropic, Feb 2026" /></a>
-  &nbsp;&nbsp;
-  <a href="https://zackproser.com/blog/a16z-sf-dec-2023-ai-apps-production"><img src="https://zackproser.b-cdn.net/images/a16z-3.webp" width="440" alt="Presenting at a16z San Francisco, Dec 2023" /></a>
+  <a href="https://zackproser.com/blog/claude-cowork-workshop-anthropic"><img src="https://zackproser.b-cdn.net/images/claude-cowork-martijn-lancee.webp" width="290" alt="Full crowd at the Claude Cowork GTM Workshop — WorkOS x Anthropic, Feb 2026" /></a>
+  &nbsp;
+  <a href="https://www.youtube.com/watch?v=kwIzRkzO_Z4"><img src="https://img.youtube.com/vi/kwIzRkzO_Z4/maxresdefault.jpg" width="290" alt="DevSecCon 2025 Keynote — Watch on YouTube" /></a>
+  &nbsp;
+  <a href="https://zackproser.com/blog/a16z-sf-dec-2023-ai-apps-production"><img src="https://zackproser.b-cdn.net/images/a16z-3.webp" width="290" alt="Presenting at a16z San Francisco, Dec 2023" /></a>
 </p>
 
 | Event | What | When |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@
 
 <br clear="right"/>
 
+<a href="https://www.youtube.com/watch?v=kwIzRkzO_Z4"><img src="https://zackproser.b-cdn.net/images/devseccon-2025-keynote.webp" width="420" alt="DevSecCon 2025 Keynote — Watch on YouTube" align="right" /></a>
+
+- **[DevSecCon 2025 Keynote](https://www.youtube.com/watch?v=kwIzRkzO_Z4)** — Delivered the keynote address on AI and security. 32-minute talk covering how AI agents are reshaping the security landscape.
+
+<br clear="right"/>
+
 <a href="https://zackproser.com/blog/walking-and-talking-with-ai"><img src="https://zackproser.b-cdn.net/images/walking-talking-ai.webp" width="420" alt="Voice-first development from the trails" align="right" /></a>
 
 - **Voice-first development** — Ship production code at 179 WPM using WisprFlow. Orchestrate multiple AI agents by voice from mountain trails. ([Read more](https://zackproser.com/blog/walking-and-talking-with-ai))
@@ -71,11 +77,9 @@
 ### Speaking & Workshops
 
 <p align="center">
-  <a href="https://zackproser.com/blog/claude-cowork-workshop-anthropic"><img src="https://zackproser.b-cdn.net/images/claude-cowork-martijn-lancee.webp" width="290" alt="Full crowd at the Claude Cowork GTM Workshop — WorkOS x Anthropic, Feb 2026" /></a>
-  &nbsp;
-  <a href="https://www.youtube.com/watch?v=kwIzRkzO_Z4"><img src="https://zackproser.b-cdn.net/images/devseccon-2025-keynote.webp" width="290" alt="DevSecCon 2025 Keynote — Watch on YouTube" /></a>
-  &nbsp;
-  <a href="https://zackproser.com/blog/a16z-sf-dec-2023-ai-apps-production"><img src="https://zackproser.b-cdn.net/images/a16z-3.webp" width="290" alt="Presenting at a16z San Francisco, Dec 2023" /></a>
+  <a href="https://zackproser.com/blog/claude-cowork-workshop-anthropic"><img src="https://zackproser.b-cdn.net/images/claude-cowork-martijn-lancee.webp" width="440" alt="Full crowd at the Claude Cowork GTM Workshop — WorkOS x Anthropic, Feb 2026" /></a>
+  &nbsp;&nbsp;
+  <a href="https://zackproser.com/blog/a16z-sf-dec-2023-ai-apps-production"><img src="https://zackproser.b-cdn.net/images/a16z-3.webp" width="440" alt="Presenting at a16z San Francisco, Dec 2023" /></a>
 </p>
 
 | Event | What | When |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
 <p align="center">
   <a href="https://zackproser.com/blog/claude-cowork-workshop-anthropic"><img src="https://zackproser.b-cdn.net/images/claude-cowork-martijn-lancee.webp" width="290" alt="Full crowd at the Claude Cowork GTM Workshop — WorkOS x Anthropic, Feb 2026" /></a>
   &nbsp;
-  <a href="https://www.youtube.com/watch?v=kwIzRkzO_Z4"><img src="https://img.youtube.com/vi/kwIzRkzO_Z4/maxresdefault.jpg" width="290" alt="DevSecCon 2025 Keynote — Watch on YouTube" /></a>
+  <a href="https://www.youtube.com/watch?v=kwIzRkzO_Z4"><img src="https://zackproser.b-cdn.net/images/devseccon-2025-keynote.webp" width="290" alt="DevSecCon 2025 Keynote — Watch on YouTube" /></a>
   &nbsp;
   <a href="https://zackproser.com/blog/a16z-sf-dec-2023-ai-apps-production"><img src="https://zackproser.b-cdn.net/images/a16z-3.webp" width="290" alt="Presenting at a16z San Francisco, Dec 2023" /></a>
 </p>


### PR DESCRIPTION
Adds the YouTube thumbnail for the DevSecCon 2025 keynote as a clickable image in the Speaking section, alongside the Cowork workshop and a16z photos. Three images in a row now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; the main impact is an additional external YouTube link and image in `README.md`.
> 
> **Overview**
> Adds a third clickable image to the `README.md` **Speaking & Workshops** gallery, linking to the DevSecCon 2025 keynote on YouTube.
> 
> Updates the speaking table to include the DevSecCon 2025 keynote entry (AI + security, 2025).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab6d425910c57d62718474f7565ec787b9c6948f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->